### PR TITLE
Pin proto-opentelemetry-proto

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - cross_compile_grpc_cpp_plugin_path.patch  # [build_platform != target_platform]
 
 build:
-  number: 1
+  number: 2
   always_include_files:
     # Must overwrite the ones installed by cpp-opentelemetry-api
     - lib/cmake/opentelemetry-cpp/  # [unix]
@@ -23,7 +23,7 @@ requirements:
     - {{ compiler('cxx') }}
     - cmake >=3.1
     - ninja
-    - proto-opentelemetry-proto
+    - proto-opentelemetry-proto =0.11.0
 
     # For cross-compiling
     - curl                # [build_platform != target_platform]


### PR DESCRIPTION
This is because proto-opentelemetry-proto is updating to v0.12.0 (https://github.com/conda-forge/proto-opentelemetry-proto-feedstock/pull/1) but we don't want to update on accident.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.
